### PR TITLE
Update Recipe `id` property

### DIFF
--- a/Cookcademy/Models/Recipe.swift
+++ b/Cookcademy/Models/Recipe.swift
@@ -8,7 +8,11 @@
 import Foundation
 
 struct Recipe: Identifiable {
-    var id = UUID()
+    var id: UUID {
+        get {
+            UUID()
+        }
+    }
     
     var mainInformation: MainInformation
     var ingredients: [Ingredient]


### PR DESCRIPTION
This one was a nifty little thing - took me about 10-15 to figure out and solve. Using `var id = UUID()`, the `id` is the same for EVERY emptyRecipe reference we call. Because of this, if we open the app, create a test recipe with your "Auto create a test recipe" button then press the "+", it will create a "new" but not new recipe called "test". If we go back to the recipes, and click on "test", it will work the first time (since it will be unique). But, after the 2nd or 3rd time, it registers that there are multiple "unique" recipes and tries to open multiple RecipeDetailViews and then closes them all and goes back to the list view. 

Feel free to change the code as you desire, but this is the quick solution I came up with to mitigate the problem at hand.