### PR TITLE
Patch for id bug from before

### DIFF
--- a/Cookcademy/Models/Recipe.swift
+++ b/Cookcademy/Models/Recipe.swift
@@ -100,12 +100,14 @@ struct Ingredient: RecipeComponent {
 
 
 extension Recipe {
-    static let emptyRecipe = Recipe(mainInformation: MainInformation(name: "",
+    static let emptyRecipe: Recipe { Recipe(mainInformation: MainInformation(name: "",
                                                                      description: "",
                                                                      author: "",
                                                                      category: .breakfast),
                                     ingredients: [],
                                     directions: [])
+                                   }
+    
     static let testRecipes: [Recipe] = [
         Recipe(mainInformation: MainInformation(name: "Dad's Mashed Potatoes",
                                                          description: "Buttery salty mashed potatoes!",

--- a/Cookcademy/Views/ExploreRecipes/RecipesListView.swift
+++ b/Cookcademy/Views/ExploreRecipes/RecipesListView.swift
@@ -32,6 +32,7 @@ struct RecipesListView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
                     isPresenting = true
+                    newRecipe.mainInformation.category = recipes[0].mainInformation.category
                 }, label: {
                     Image(systemName: "plus")
                 })

--- a/Cookcademy/Views/ExploreRecipes/RecipesListView.swift
+++ b/Cookcademy/Views/ExploreRecipes/RecipesListView.swift
@@ -32,6 +32,7 @@ struct RecipesListView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
                     isPresenting = true
+                    newRecipe = Recipe.emptyRecipe
                     newRecipe.mainInformation.category = recipes[0].mainInformation.category
                 }, label: {
                     Image(systemName: "plus")


### PR DESCRIPTION
So, I was looking into your solution fix of the random integer - and although it fixes the problem for that specific article, it doesn't fix the problem where:

1. People create custom recipes that are all identical (it will end up with the same id and cause the same issue)
2. The form is not reset when you click on the "+" on multiple items - resulting in the problem above if they don't change anything
3. Each time you use `emptyRecipe`, it gives the same `id` since nothing is changing - the recipe itself stays the same.

My proposed fix does the following:

1. Create a new `testRecipe` each time it is called.
2. Resets the `newRecipe` each time the "+" is tapped
3. Small thing: It defaults to the current category when selecting the "+"

Result:
1. Create recipes that can be identical (but are not because the `id` will be 100% different
2. Clear the forms after reset so users don't have to clear the forms (especially on longer recipes)
3. The recipe goes in the desired category by defaul

I'm not 100% sure this fixes absolutely everything in the application as I only tested to see that the `id` would print out differently for each new "+" tapped and the `ModifyRecipes` forms would be reset. 