### PR TITLE
Patch for branch1 recipe model

### DIFF
--- a/Cookcademy/Recipe.swift
+++ b/Cookcademy/Recipe.swift
@@ -65,7 +65,7 @@ struct Ingredient {
 }
 
 extension Recipe {
-    static let emptyRecipe: Recipe { Recipe(mainInformation: MainInformation(name: "",
+    static var emptyRecipe: Recipe { Recipe(mainInformation: MainInformation(name: "",
                                                                      description: "",
                                                                      author: "",
                                                                      category: .breakfast),


### PR DESCRIPTION
The computed property `emptyRecipe` must be a `var` and not `let`.