### PR TITLE
Patch for branch3 category grid view

### DIFF
--- a/Cookcademy/Models/Recipe.swift
+++ b/Cookcademy/Models/Recipe.swift
@@ -68,7 +68,7 @@ struct Ingredient {
 
 
 extension Recipe {
-    static let emptyRecipe: Recipe { Recipe(mainInformation: MainInformation(name: "",
+    static var emptyRecipe: Recipe { Recipe(mainInformation: MainInformation(name: "",
                                                                      description: "",
                                                                      author: "",
                                                                      category: .breakfast),

--- a/Cookcademy/Views/RecipeCategoryGridView.swift
+++ b/Cookcademy/Views/RecipeCategoryGridView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct RecipeCateogryGridView: View {
+struct RecipeCategoryGridView: View {
     @StateObject private var recipeData = RecipeData()
 
     var body: some View {
@@ -38,7 +38,7 @@ struct CategoryView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .opacity(0.35)
-            Text(category.rawValue.capitalized)
+            Text(category.rawValue)
                 .font(.title)
         }
     }

--- a/Cookcademy/Views/RecipeCategoryGridView.swift
+++ b/Cookcademy/Views/RecipeCategoryGridView.swift
@@ -44,7 +44,7 @@ struct CategoryView: View {
     }
 }
 
-struct RecipeCateogryGridView_Previews: PreviewProvider {
+struct RecipeCategoryGridView_Previews: PreviewProvider {
     static var previews: some View {
         RecipeCateogryGridView()
     }


### PR DESCRIPTION
- Remove `.capitalized` since the `category.rawValue` is already capitalized.
- Was `struct RecipeCateogryGridView` typo - corrected to `struct RecipeCategoryGridView`