### PR TITLE
Bug patch for branch 6

### DIFF
--- a/Cookcademy/Models/Recipe.swift
+++ b/Cookcademy/Models/Recipe.swift
@@ -47,16 +47,6 @@ struct Ingredient {
     var quantity: Double
     var unit: Unit
     
-    init(name: String, quantity: Double, unit: Unit) {
-        self.name = name
-        self.quantity = quantity
-        self.unit = unit
-    }
-    
-    init() {
-        self.init(name: "", quantity: 1.0, unit: .none)
-    }
-    
     var description: String {
         let formattedQuanity = String(format: "%g", quantity)
         switch unit {
@@ -81,6 +71,10 @@ struct Ingredient {
         case none = "No units"
         
         var singularName: String { String(rawValue.dropLast()) }
+    }
+    
+    static var emptyIngredient: Ingredient {
+        Ingredient(name: "", quantity: 1.0, unit: .none)   
     }
 }
 

--- a/Cookcademy/Views/ModifyRecipes/ModifyIngredientView.swift
+++ b/Cookcademy/Views/ModifyRecipes/ModifyIngredientView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ModifyIngredientView: View {
     @Binding var ingredient: Ingredient
-    let createAction: ((Ingredient) -> Void)
+    let createAction: ((Bool) -> Void)
     
     private let listBackgroundColor = AppColor.background
     private let listTextColor = AppColor.foreground
@@ -42,7 +42,7 @@ struct ModifyIngredientView: View {
             HStack {
                 Spacer()
                 Button("Save") {
-                    createAction(ingredient)
+                    createAction(true)
                     mode.wrappedValue.dismiss()
                 }
                 Spacer()
@@ -64,8 +64,8 @@ struct ModifyIngredientView_Previews: PreviewProvider {
     @State static var recipe = Recipe.testRecipes[0]
     static var previews: some View {
         NavigationView {
-           ModifyIngredientView(ingredient: $recipe.ingredients[0]) { ingredient in
-                print(ingredient)
+           ModifyIngredientView(ingredient: $recipe.ingredients[0]) { didAddRecipe in
+                print(didAddRecipe)
             }.navigationTitle("Add Ingredient")
         }
     }

--- a/Cookcademy/Views/ModifyRecipes/ModifyIngredientsView.swift
+++ b/Cookcademy/Views/ModifyRecipes/ModifyIngredientsView.swift
@@ -13,13 +13,13 @@ struct ModifyRecipeIngredientsView: View {
     private let listBackgroundColor = AppColor.background
     private let listTextColor = AppColor.foreground
 
-    @State private var newIngredient = Ingredient()
+    @State private var newIngredient = Ingredient.emptyIngredient
+    @State var didAddRecipe: Bool = false
     
     var body: some View {
         VStack {
-            let addIngredientView = ModifyIngredientView(ingredient: $newIngredient) { ingredient in
-                ingredients.append(ingredient)
-                newIngredient = Ingredient()
+            let addIngredientView = ModifyIngredientView(ingredient: $newIngredient) { didAddRecipe in
+                self.didAddRecipe = didAddRecipe
             }.navigationTitle("Add Ingredient")
             if ingredients.isEmpty {
                 Spacer()
@@ -43,6 +43,12 @@ struct ModifyRecipeIngredientsView: View {
                         .buttonStyle(PlainButtonStyle())
                         .listRowBackground(listBackgroundColor)
                 }.foregroundColor(listTextColor)
+            }
+        }.onAppear(perform: {
+            if didAddRecipe {
+                ingredients.append(newIngredient)
+                newIngredient = Ingredient.emptyRecipe
+                didAddRecipe = false
             }
         }
     }


### PR DESCRIPTION
Okay - this was a doozy, as they say.

**Problem:**
The save button was dismissing the `ModifyIngredientView` prior to implementing the `dismiss` section. This happened because the `if ingredients.isEmpty` registered as a change since the `ingredients` was no longer empty. The ingredient was added, the `ModifyIngredientView` was removed, and the new ingredient was shown, all without the specific `dismiss` capability.
- This made it difficult to illustrate the .gif since it shouldn't have been dismissing.

**Proposed Solution:**
The save button now validates that the "Save" buton was pressed using a `Bool`. 
The view now implements an `onAppear` method. This method will check if the `Bool` is true - and if so, that means the save button was pressed. From there, we add the ingredient. Theoretically, we could have used another binding for this - but then we wouldn't have a closure. I figured since we need closures, this was a simple workaround. 

**Final Product:**
Now, if you were to comment out the `mode.dismiss` code - it would ONLY save and not dismiss the view. The dismiss view kind of masked this issue. 

------------

The `Ingredient` initializers seemed to be out of place. Correct me if I'm wrong, but a computed property much like `emptyRecipe` matches the tone of the codebase. Additionally, since the computation is not difficult here, it seems that a computed property might be more appropriate. Do you recommend this?