### PR TITLE
Update RecipesListView.swift

### DIFF
--- a/Cookcademy/Views/ExploreRecipes/RecipesListView.swift
+++ b/Cookcademy/Views/ExploreRecipes/RecipesListView.swift
@@ -32,7 +32,7 @@ struct RecipesListView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
                     newRecipe = Recipe()
-                    newRecipe.mainInformation.category = recipes[0].mainInformation.category
+                    newRecipe.mainInformation.category = recipes.count > 0 ? recipes[0].mainInformation.category : .breakfast
                     isPresenting = true
                 }, label: {
                     Image(systemName: "plus")

--- a/Cookcademy/Views/ExploreRecipes/RecipesListView.swift
+++ b/Cookcademy/Views/ExploreRecipes/RecipesListView.swift
@@ -32,7 +32,7 @@ struct RecipesListView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
                     newRecipe = Recipe()
-                    newRecipe.mainInformation.category = recipes.count > 0 ? recipes[0].mainInformation.category : .breakfast
+                    newRecipe.mainInformation.category = recipes.first?.mainInformation.category ?? .breakfast
                     isPresenting = true
                 }, label: {
                     Image(systemName: "plus")


### PR DESCRIPTION
Problem:
1. Open Application on Simulator (or previews)
2. Click on "Favorites" at the bottom
3. Press the "+" button at the top right.
- This causes the app to crash because it is referncing line 35 trying to assign the category to `recipes[0].mainInformation.category` - but there might not be any "favorite" recipes and it crashes with an out of bounds error.

Solution: Just check if `recipes.count` > 0 , if not, just assign `.breakfast`.